### PR TITLE
Add "array" to the list of tokens whose values get lowercased

### DIFF
--- a/src/FlashX_RecipeTools/utils/generate_op_spec.py
+++ b/src/FlashX_RecipeTools/utils/generate_op_spec.py
@@ -267,7 +267,7 @@ def __adjust_token_keys(tokens: dict) -> dict:
     for key in tokens:
         adjusted_key = key.lower()
         adjusted_token = tokens[key]
-        if adjusted_key in ["common", "lbound", "type", "extents"]:
+        if adjusted_key in ["common", "lbound", "type", "extents", "array"]:
             adjusted_token = adjusted_token.lower()
         adjusted[adjusted_key] = adjusted_token
     return adjusted


### PR DESCRIPTION
It appears this change in FlashX_RecipeTools is enough to make several recent "fixes" that I made in the Milhoja repository unnecessary. I shall revert those recent changes there.

The Isssue in question was getting something like
`loU::source=lbound,array=U`, `U::source=grid_data,...` in a Unit_interface.F90 file to be interpreted correctly.