### PR TITLE
Update generate_op_spec.py

### DIFF
--- a/src/FlashX_RecipeTools/utils/generate_op_spec.py
+++ b/src/FlashX_RecipeTools/utils/generate_op_spec.py
@@ -53,7 +53,7 @@ def evaluate_simple_expression(line: str) -> int:
             if op_stack:
                 while op_stack and op_stack[-1] != "(" and \
                 (ops[op_stack[-1]]["priority"] > ops[token]["priority"] or \
-                (ops[op_stack[-1]]["priority"] == ops[token]["side"] and \
+                (ops[op_stack[-1]]["priority"] == ops[token]["priority"] and \
                 ops[token]["side"] == 'L')):
                     out_queue.append(op_stack.pop())
             op_stack.append(token)


### PR DESCRIPTION
Fix a coding error that was preventing left-associativity for arithmetic operations from being used properly. 
This is in the code that is used for handling arithmetic expressions in scratch array `extents` in Milhoja annotations in `*_interface.F90` files. 
For example, an expression (or subexpression) of the form `a - b + c` would be misinterpreted as `a - (b + c)`, resulting in scratch array storage being allocated with the wrong size.